### PR TITLE
Formatted posting/expiration dates and times

### DIFF
--- a/TRT-django/marketplace/templates/marketplace/list_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/list_item_requests.html
@@ -35,7 +35,7 @@
                         {%else%}
                         <p class="card-text"><i class="fas fa-tag"></i> ${{item_request.price}} USD</p>
                         {%endif%}
-                        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}}</p>
+                        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}} ET</p>
                         <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item_request.deadline}}</p>
                         <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i>&nbsp;Quality</p>
                         {% if item_request.condition == Item.NEW%}
@@ -119,7 +119,7 @@
                             {%else%}
                             <p class="card-text"><i class="fas fa-tag"></i> ${{item_request.price}} USD</p>
                             {%endif%}
-                            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}}</p>
+                            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}} ET</p>
                             <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item_request.deadline}}</p>
                             <p class="card-text"><i class="fas fa-comment"></i> {{item_request.description}}</p>
                             <p class="card-text"><i class="fas fa-phone"></i> {{item_request.requester.contact}}</p>

--- a/TRT-django/marketplace/templates/marketplace/list_items.html
+++ b/TRT-django/marketplace/templates/marketplace/list_items.html
@@ -28,7 +28,7 @@
             {%else%}
             <p class="card-text"><i class="fas fa-tag"></i> ${{item.price}} USD</p>
             {%endif%}
-            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}}</p>
+            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}} ET</p>
             <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item.deadline}}</p>
             <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i>&nbsp;Quality</p>
             {% if item.condition == Item.NEW%}
@@ -220,7 +220,7 @@
                   {%else%}
                   <p class="card-text"><i class="fas fa-tag"></i> ${{item.price}} USD</p>
                   {%endif%}
-                  <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}}</p>
+                  <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}} ET</p>
                   <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item.deadline}}</p>
                   <p class="card-text"><i class="fas fa-comment"></i> {{item.description}}</p>
                   <p class="card-text"><i class="fas fa-phone"></i> &nbsp;{{item.seller.contact}}</p>

--- a/TRT-django/marketplace/templates/marketplace/list_purchases.html
+++ b/TRT-django/marketplace/templates/marketplace/list_purchases.html
@@ -30,7 +30,7 @@
             {%else%}
             <p class="card-text"><i class="fas fa-tag"></i> ${{purchase.item.price}} USD</p>
             {%endif%}
-            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{purchase.item.posted_date}}</p>
+            <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{purchase.item.posted_date}} ET</p>
             <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{purchase.item.deadline}}</p>
             <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i>&nbsp;Quality</p>
             {% if purchase.item.condition == Item.NEW%}
@@ -186,7 +186,7 @@
                   {%else%}
                   <p class="card-text"><i class="fas fa-tag"></i> ${{purchase.item.price}} USD</p>
                   {%endif%}
-                  <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{purchase.item.posted_date}}</p>
+                  <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{purchase.item.posted_date}} ET</p>
                   <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{purchase.item.deadline}}</p>
                   <p class="card-text"><i class="fas fa-comment"></i> {{purchase.item.description}}</p>
 

--- a/TRT-django/marketplace/templates/marketplace/page_item.html
+++ b/TRT-django/marketplace/templates/marketplace/page_item.html
@@ -51,7 +51,7 @@
         {%else%}
         <p class="card-text"><i class="fas fa-tag"></i> ${{item.price}} USD</p>
         {%endif%}
-        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}}</p>
+        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}} ET</p>
         <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item.deadline}}</p>
         <p class="card-text"><i class="fas fa-comment"></i> {{item.description}}</p>
         <p class="card-text"><i class="fas fa-phone"></i>{{item.seller.contact}}</p>

--- a/TRT-django/marketplace/templates/marketplace/page_item_request.html
+++ b/TRT-django/marketplace/templates/marketplace/page_item_request.html
@@ -32,7 +32,7 @@
         {%else%}
         <p class="card-text"><i class="fas fa-tag"></i> ${{item_request.price}} USD</p>
         {%endif%}
-        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}}</p>
+        <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}} ET</p>
         <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item_request.deadline}}</p>
         <p class="card-text"><i class="fas fa-comment"></i> {{item_request.description}}</p>
         <p class="card-text"><i class="fas fa-phone"></i>{{item_request.requester.contact}}</p>

--- a/TRT-django/marketplace/templates/marketplace/report_item_card.html
+++ b/TRT-django/marketplace/templates/marketplace/report_item_card.html
@@ -16,7 +16,7 @@
               {%else%}
               <p class="card-text"><i class="fas fa-tag"></i> ${{item.price}} USD</p>
               {%endif%}
-              <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}}</p>
+              <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}} ET</p>
               <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item.deadline}}</p>
               <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i>&nbsp;Quality</p>
               {% if item.condition == Item.NEW%}
@@ -117,7 +117,7 @@
                     {%else%}
                     <p class="card-text"><i class="fas fa-tag"></i> ${{item.price}} USD</p>
                     {%endif%}
-                    <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}}</p>
+                    <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item.posted_date}} ET</p>
                     <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item.deadline}}</p>
                     <p class="card-text"><i class="fas fa-comment"></i> {{item.description}}</p>
                     <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i> Quality</p>

--- a/TRT-django/marketplace/templates/marketplace/report_item_request_card.html
+++ b/TRT-django/marketplace/templates/marketplace/report_item_request_card.html
@@ -16,7 +16,7 @@
         {%else%}
         <p class="card-text"><i class="fas fa-tag"></i> ${{item_request.price}} USD</p>
         {%endif%}
-        <p class="card-text"> <i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}}</p>
+        <p class="card-text"> <i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}} ET</p>
         <p class="card-text"> <i class="fas fa-hourglass-end"></i> Expires {{item_request.deadline}}</p>
         <p class="card-text"> <i class="fa fa-check" aria-hidden="true"></i> Quality </p>
         {% if item_request.condition == Item.NEW%}
@@ -91,7 +91,7 @@
               {%else%}
               <p class="card-text"><i class="fas fa-tag"></i> ${{item_request.price}} USD</p>
               {%endif%}
-              <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}}</p>
+              <p class="card-text"><i class="fas fa-hourglass-start"></i> Posted {{item_request.posted_date}} ET</p>
               <p class="card-text"><i class="fas fa-hourglass-end"></i> Expires {{item_request.deadline}}</p>
               <p class="card-text"><i class="fas fa-comment"></i> {{item_request.description}}</p>
               <p class="card-text"><i class="fa fa-check" aria-hidden="true"></i> Quality</p>

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -506,7 +506,7 @@ def getItemsRelative(request):
                 {
                     "pk": item.pk,
                     "name": item.name,
-                    "posted_date": item.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p"),
+                    "posted_date": item.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p") + " ET",
                     "deadline": item.deadline.strftime("%b. %-d, %Y"),
                     "price": item.price,
                     "negotiable": item.negotiable,
@@ -1626,7 +1626,7 @@ def getItemRequestsRelative(request):
                 {
                     "pk": item_request.pk,
                     "name": item_request.name,
-                    "posted_date": item_request.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p"),
+                    "posted_date": item_request.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p") + " ET",
                     "deadline": item_request.deadline.strftime("%b. %-d, %Y"),
                     "price": item_request.price,
                     "negotiable": item_request.negotiable,

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -506,8 +506,8 @@ def getItemsRelative(request):
                 {
                     "pk": item.pk,
                     "name": item.name,
-                    "posted_date": item.posted_date.strftime("%Y-%m-%d"),
-                    "deadline": item.deadline,
+                    "posted_date": item.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p"),
+                    "deadline": item.deadline.strftime("%b. %-d, %Y"),
                     "price": item.price,
                     "negotiable": item.negotiable,
                     "condition_index": item.condition,
@@ -1626,8 +1626,8 @@ def getItemRequestsRelative(request):
                 {
                     "pk": item_request.pk,
                     "name": item_request.name,
-                    "posted_date": item_request.posted_date.strftime("%Y-%m-%d"),
-                    "deadline": item_request.deadline,
+                    "posted_date": item_request.posted_date.astimezone().strftime("%b. %-d, %Y, %-I:%M %p"),
+                    "deadline": item_request.deadline.strftime("%b. %-d, %Y"),
                     "price": item_request.price,
                     "negotiable": item_request.negotiable,
                     "condition_index": item_request.condition,


### PR DESCRIPTION
## Changes
* Affects the main "Browse items" and "Browse requests" pages
* Added time of posting to each listing
* Formatted posting and expiration dates to match other pages and improve readability
* Bugfix: made dates/times consistent across different pages, where they were previously offset by some hours (depending on timezone)

### Before:
<img width="300" alt="Screen Shot 2022-12-27 at 12 20 02 AM" src="https://user-images.githubusercontent.com/90424009/209615536-88ca25b9-32d7-464f-85fd-17cb540b859f.png">
<img width="1091" alt="Screen Shot 2022-12-27 at 12 20 14 AM" src="https://user-images.githubusercontent.com/90424009/209615537-9ec2b069-c344-4819-b5c1-52c64440ebd5.png">

### After:
<img width="282" alt="Screen Shot 2022-12-27 at 12 23 15 AM" src="https://user-images.githubusercontent.com/90424009/209615539-ffe9cb9d-485e-472e-8db7-bc1ac708dc47.png">
<img width="1083" alt="Screen Shot 2022-12-27 at 12 22 54 AM" src="https://user-images.githubusercontent.com/90424009/209615538-7ea37aff-8d7f-48fd-8916-dc368ae3f0b7.png">
