### PR TITLE
Consolidation of TigerThift and Rebook

### DIFF
--- a/TRT-django/TRT/settings.py
+++ b/TRT-django/TRT/settings.py
@@ -164,7 +164,7 @@ CACHES = {
 }
 
 # list of usernames for which we allow multi-accounts
-ADMIN_USERNAMES = ["ptn_aklin", "ptn_singl", "ptn_kjm3", "ptn_sarats", "ptn_ca9"]
+ADMIN_USERNAMES = ["ptn_aklin", "ptn_singl", "ptn_kjm3", "ptn_sarats", "ptn_ca9", "ptn_ntyp"]
 # list of alt account suffixes for admins
 ALT_ACCOUNT_SUFFIXES = ["", "_alt_a", "_alt_b"]
 # list of emails to send admin notices to

--- a/TRT-django/marketplace/models.py
+++ b/TRT-django/marketplace/models.py
@@ -112,10 +112,7 @@ class Item(models.Model):
             (CONDITION['index'], CONDITION['name']) for CONDITION in CONDITIONS
         ],
     )
-    categories = models.ManyToManyField(
-        Category, 
-        help_text=mark_safe("""Sell textbooks on <a href="https://rebook.tigerapps.org/" target="_blank">rebook</a>""")
-    )
+    categories = models.ManyToManyField(Category)
     description = models.CharField(max_length=1000)
     image = models.ImageField(upload_to="images/")
     status = models.DecimalField(
@@ -242,10 +239,7 @@ class ItemRequest(models.Model):
             (CONDITION['index'], CONDITION['name']) for CONDITION in Item.CONDITIONS
         ],
     )
-    categories = models.ManyToManyField(
-            Category,
-            help_text=mark_safe("""Find textbooks on <a href="https://rebook.tigerapps.org/" target="_blank">rebook</a>""")
-)
+    categories = models.ManyToManyField(Category)
     description = models.CharField(max_length=1000)
     image = models.ImageField(upload_to="images/")
 

--- a/TRT-django/marketplace/models.py
+++ b/TRT-django/marketplace/models.py
@@ -30,6 +30,9 @@ class Account(models.Model):
 class Category(models.Model):
     name = models.CharField(max_length=50)
     description = models.CharField(max_length=200)
+    
+    class Meta:
+        ordering = ["name"]
 
     def __str__(self):
         return self.name

--- a/TRT-django/marketplace/templates/marketplace/base.html
+++ b/TRT-django/marketplace/templates/marketplace/base.html
@@ -29,9 +29,9 @@
 </head>
 
 <body>
-    <!-- <div class="alert alert-danger show my-0 py-2 fw-bolder" role="alert">
-        In-app messaging was permanently removed on November 27, 2022. All conversations must take place via the contact info provided on the listing.
-    </div> -->
+    <div class="alert alert-danger show my-0 py-2 fw-bolder" role="alert">
+        Rebook and TigerThrift have been retired. Creators of listings have been asked to repost on TigerReTail.
+    </div>
 
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: rgb(245, 174, 81);">
         <div class="container-fluid">

--- a/TRT-django/marketplace/templates/marketplace/base.html
+++ b/TRT-django/marketplace/templates/marketplace/base.html
@@ -29,9 +29,9 @@
 </head>
 
 <body>
-    <div class="alert alert-danger show my-0 py-2 fw-bolder" role="alert">
+    <!-- <div class="alert alert-danger show my-0 py-2 fw-bolder" role="alert">
         In-app messaging was permanently removed on November 27, 2022. All conversations must take place via the contact info provided on the listing.
-    </div>
+    </div> -->
 
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: rgb(245, 174, 81);">
         <div class="container-fluid">

--- a/TRT-django/marketplace/templates/marketplace/faq.html
+++ b/TRT-django/marketplace/templates/marketplace/faq.html
@@ -88,19 +88,6 @@
             </div>
             </div>
         </div>
-
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="headingSeven">
-            <button class="accordion-button bg-light hover-grey collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
-                Why is there no "books" category?
-            </button>
-            </h2>
-            <div id="collapseSeven" class="accordion-collapse collapse" aria-labelledby="headingSeven" data-bs-parent="#accordionParent">
-            <div class="accordion-body">
-                All textbook sales occur on a different site, called <a href="https://rebook.tigerapps.org/" target="_blank">rebook</a>. rebook is a marketplace specifically curated for textbooks. Since the majority of books sold and requested are textbooks, the "books" category was removed from TigerReTail to encourage sellers and buyers to use rebook and ensure that textbook sales are centralized on one platform, making it easier for everyone to sell and search for textbooks. Non-textbook book sales and requests fall under the "other" category.
-            </div>
-            </div>
-        </div>
     </div>
 
 {% endblock content %}

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -62,7 +62,7 @@
 
   <div class="container my-4">
     <div id="gallery_title">Items for Sale</div>
-    <p>Purchase items here. Buy textbooks on <a href="https://rebook.tigerapps.org/" target="_blank">rebook</a>. Check out our FAQ for more.</p>
+    <p>Purchase items here. Check out our FAQ for more.</p>
     <div class="form-check">
         <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
         <label class="form-check-label" for="table_toggle">


### PR DESCRIPTION
## Summary

TigerThrift and Rebook unfortunately don't receive enough traffic to justify their hosting and database costs (each of which are the same as TigerReTail's), and they cause a split in the marketplace category userbase. This PR facilitates the consolidation of TigerThrift and Rebook into TigerReTail by removing some wording and fixing up listing categories.

The "textbooks" category has been added back to TigerReTail via the Django shell (i.e. by creating a new `Category` object), and the "clothing" category already exists.

## Consolidation plan

This PR should be merged as the first step of the consolidation/retirement process.

**All authors of listings on Rebook and TigerThrift will be contacted and given x number of days to repost their listing on TigerReTail.**

* All listings and email addresses for TigerReTail: https://docs.google.com/spreadsheets/d/1F07ikxmTOeNs-oxfil-uXnbDX6dizZMP7p5rd7Vuxhc/edit#gid=0
* ... Rebook: https://docs.google.com/spreadsheets/d/12C_Tf-zqzHAZteF84OLJ7XM6xlMuQwV4gUnWdIzqjOM/edit#gid=0
* Proposed email to students who created listings: https://docs.google.com/document/d/1QIKJdoS2bI7ndYgsThRLhCaJYOl5ciZl3pOB7zyxSUQ/edit

After x days, we can retire TigerThrift and Rebook.